### PR TITLE
skip automatic indentation inside comments

### DIFF
--- a/crates/go/src/interface.rs
+++ b/crates/go/src/interface.rs
@@ -1073,7 +1073,6 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 self.preamble
                     .push_str(&format!("// typedef struct {c_typedef_target} "));
                 self.preamble.push_str("{");
-                self.preamble.deindent(1);
                 self.preamble.push_str("\n");
                 self.preamble.push_str("//  int32_t __handle; \n");
                 self.preamble.push_str("// ");


### PR DESCRIPTION
This fixes broken indentation due to
e.g. `wasi:io/streams#output-stream.blocking-write-and-flush`, which has a doc comment that contains curly brackets.

This isn't generally a problem for Rust, which uses `rustfmt` if available, but leads to headaches for C if `clang-format` isn't handy.